### PR TITLE
Publish Microsoft Authored templates to azure samples browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+---
+page_type: sample
+languages:
+- azdeveloper
+- python
+- bicep
+products:
+- azure
+- azure-container-apps
+- azure-service-bus
+- dapr
+urlFragment: pubsub-dapr-python-servicebus
+name: Microservice communication using pubsub (async)(Python)
+description: Create a publisher microservice and a subscriber microservice with Python to demonstrate how Dapr enables a publish-subcribe pattern. The publisher will generate messages of a specific topic, while subscribers will listen for messages of specific topics. 
+---
+<!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
+
 # Microservice communication using pubsub (async)
 
 ![](images/pubsub-diagram.png)


### PR DESCRIPTION
Publish `pubsub-dapr-python-servicebus` template to azure samples browser.

@rajeshkamal5050 and @hemarina for notification.